### PR TITLE
Fix saved positioning for widgets.

### DIFF
--- a/js/draggable.js
+++ b/js/draggable.js
@@ -1,5 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
-    document.querySelectorAll(".draggable-component").forEach(makeDraggable);
+    document.querySelectorAll(".draggable-component").forEach(element => {
+        makeDraggable(element);
+    });
 });
 
 function makeDraggable(element) {
@@ -45,8 +47,9 @@ function makeDraggable(element) {
         // Stop moving when mouse is released
         document.removeEventListener('mouseup', onMouseUp);
         document.removeEventListener('mousemove', onMouseMove);
-
+        const xKey = `${element.id.split('-')[0].toLowerCase()}X`;
+        const yKey = `${element.id.split('-')[0].toLowerCase()}Y`;
         // Save position of the widget after dragging
-        chrome.storage.sync.set({ 'triviaX': element.offsetLeft, 'triviaY': element.offsetTop });
+        chrome.storage.sync.set({ [xKey]: element.offsetLeft, [yKey]: element.offsetTop });
     }
 }

--- a/js/wotd.js
+++ b/js/wotd.js
@@ -42,6 +42,10 @@ const wotdWidget = {
         if (definitionContainer) {
             definitionContainer.innerText = definition;
         }
+        chrome.storage.sync.get(['wotdX', 'wotdY'], (browserData) => {
+            widgetContainer.style.left = `${browserData.wotdX}px`;
+            widgetContainer.style.top = `${browserData.wotdY}px`;
+        });
         widgetContainer.style.display = "block";
         widgetContainer.classList.add("wotd-loaded");
     }

--- a/js/wotd.js
+++ b/js/wotd.js
@@ -23,10 +23,8 @@ const wotdWidget = {
             // Extract definition
             if (data && data.length > 0) {
                 const definition = data[0].meanings[0].definitions[0].definition;
-                console.log(`Word of the Day: ${word} - ${definition}`);
                 this.populateWordAndDefinition(word, definition);
             } else {
-                console.log("Definition not found. Trying again...");
                 this.loadWordOfTheDay(); // Retry if no definition found
             }
         } catch (error) {


### PR DESCRIPTION
Behavior: users can drag their trivia and wotd widgets. On page load, these widgets will render at the saved position.